### PR TITLE
ci: copy index html

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,6 +33,9 @@ jobs:
       - name: 🏗️ Build Application
         run: pnpm build --base=/distributed-mqtt-editor
 
+      - name: 👈 Create 404.html to trigger SPA
+        run: cp dist/index.html dist/404.html
+
       - name: 🚢 Deploy to GitHub-Pages
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
Copy index.html to 404.html to enforce a SPA on GitHub Pages

https://stackoverflow.com/questions/36296012/is-there-a-configuration-in-github-pages-that-allows-you-to-redirect-everything